### PR TITLE
Support json messages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,3 +7,7 @@ steps:
   settings:
     repo: docker.funzt-halt.net/mqtt-pushgateway
     tags: latest
+
+trigger:
+  branch:
+  - master

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Caveat: Only float values are supported. Anything else will be ignored.
 *   Topics that were matched in a subscription pattern can be hidden from the
     result through a topic configuration.
 
-*   JSON messages record each key:value pair as a unique metric, eg: the payload:
+*   JSON messages record each key:value pair as a unique metric, eg: the following payload sent on topic `zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM`:
 
         {"temperature":29.02,"linkquality":34,"humidity":55.58,"battery":100,"voltage":3005}
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This exporter provides a push gateway for MQTT: You let it listen to
 some interesting MQTT topics, it collects data into metrics and waits to
 be scraped by Prometheus.
 
+Messages that can be parsed as JSON will log a unique metric per key:value pair
+using a 'virtual' topic of `topic/key`.
+
 Caveat: Only float values are supported. Anything else will be ignored.
 
 # Features
@@ -39,6 +42,17 @@ Caveat: Only float values are supported. Anything else will be ignored.
 *   Topics that were matched in a subscription pattern can be hidden from the
     result through a topic configuration.
 
+*   JSON messages record each key:value pair as a unique metric, eg: the payload:
+
+        {"temperature":29.02,"linkquality":34,"humidity":55.58,"battery":100,"voltage":3005}
+
+    would expose the following metrics:
+
+        temperature{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 29.300000
+        linkquality{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 34.000000
+        humidity{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 54.700000
+        battery{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 100.000000
+        voltage{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 3005.000000
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Caveat: Only float values are supported. Anything else will be ignored.
 
     would expose the following metrics:
 
-        temperature{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 29.300000
-        linkquality{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 34.000000
-        humidity{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 54.700000
-        battery{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 100.000000
-        voltage{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 3005.000000
+        temperature{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM/temperature"} 29.300000
+        linkquality{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM/linkquality"} 34.000000
+        humidity{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM/humidity"} 54.700000
+        battery{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM/battery"} 100.000000
+        voltage{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM/voltage"} 3005.000000
 
 # Installation
 

--- a/mqtt-pushgateway.py
+++ b/mqtt-pushgateway.py
@@ -62,7 +62,7 @@ class Topic(object):
             self.value = float(value)
             self.is_numeric = True
         except (TypeError, ValueError):
-            self.value = value.decode("utf-8")
+            self.value = value
             self.known_vals.add(self.value)
             self.is_numeric = False
 


### PR DESCRIPTION
Adds support for extracting multiple metrics from a JSON formatted message.

eg for a JSON payload `{"temperature":29.02,"linkquality":34,"humidity":55.58,"battery":100,"voltage":3005}`

create multiple metrics like:
```
temperature{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 29.300000
linkquality{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 34.000000
humidity{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 54.700000
battery{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 100.000000
voltage{topic="zigbee2mqtt/sensor/lounge/xiaomi/WSDCGQ01LM"} 3005.000000
```